### PR TITLE
Enhance todo TUI header and indentation

### DIFF
--- a/todo_cli/README.md
+++ b/todo_cli/README.md
@@ -33,6 +33,7 @@ Then use the following commands:
 - `w` to move up.
 - `s` to move down.
 - `r` to remove the selected task.
+- `z` to toggle indent on the selected task.
 
 Completed tasks are shown greyed out with a strikethrough effect.
 


### PR DESCRIPTION
## Summary
- make the TUI header huge using pyfiglet
- display key command tooltips under the header
- add ability to indent tasks with the `z` key
- document `z` in the README

## Testing
- `python -m py_compile todo_cli/todo_tui.py`
- `python -m py_compile todo_cli/todo.py`


------
https://chatgpt.com/codex/tasks/task_e_687e301fd9508324ba2da38ff24750cd