### PR TITLE
Add auto-install for pyfiglet in todo_tui

### DIFF
--- a/todo_cli/todo_tui.py
+++ b/todo_cli/todo_tui.py
@@ -2,8 +2,26 @@
 
 import curses
 import json
+import subprocess
+import sys
 from pathlib import Path
-from pyfiglet import Figlet
+
+try:
+    from pyfiglet import Figlet
+except ModuleNotFoundError:
+    print("Installing missing dependency 'pyfiglet'...")
+    subprocess.check_call([
+        sys.executable,
+        "-m",
+        "pip",
+        "install",
+        "--user",
+        "pyfiglet",
+    ])
+    import importlib, site
+    importlib.reload(site)
+    site.addsitedir(site.getusersitepackages())
+    from pyfiglet import Figlet
 
 class TodoTUI:
     """Curses based interface to display and edit todos."""


### PR DESCRIPTION
## Summary
- automatically install the `pyfiglet` dependency on first run

## Testing
- `python3 -m py_compile todo_cli/todo_tui.py`


------
https://chatgpt.com/codex/tasks/task_e_688286c65d388324bebecfedd9b33df4