### PR TITLE
Ensure launchers run from project directory

### DIFF
--- a/ffmpeg_farm/scripts/run_master_macos.command
+++ b/ffmpeg_farm/scripts/run_master_macos.command
@@ -7,4 +7,5 @@ PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 "$SCRIPT_DIR/install_macos.sh"
 
 source "$PROJECT_DIR/.venv/bin/activate"
+cd "$PROJECT_DIR"
 exec python -m ffarm master --host 0.0.0.0 --port 8000

--- a/ffmpeg_farm/scripts/run_master_ubuntu.sh
+++ b/ffmpeg_farm/scripts/run_master_ubuntu.sh
@@ -7,4 +7,5 @@ PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 "$SCRIPT_DIR/install_ubuntu.sh"
 
 source "$PROJECT_DIR/.venv/bin/activate"
+cd "$PROJECT_DIR"
 exec python -m ffarm master --host 0.0.0.0 --port 8000

--- a/ffmpeg_farm/scripts/run_slave_macos.command
+++ b/ffmpeg_farm/scripts/run_slave_macos.command
@@ -7,4 +7,5 @@ PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 "$SCRIPT_DIR/install_macos.sh"
 
 source "$PROJECT_DIR/.venv/bin/activate"
+cd "$PROJECT_DIR"
 exec python -m ffarm worker --master http://127.0.0.1:8000

--- a/ffmpeg_farm/scripts/run_slave_ubuntu.sh
+++ b/ffmpeg_farm/scripts/run_slave_ubuntu.sh
@@ -7,4 +7,5 @@ PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 "$SCRIPT_DIR/install_ubuntu.sh"
 
 source "$PROJECT_DIR/.venv/bin/activate"
+cd "$PROJECT_DIR"
 exec python -m ffarm worker --master http://127.0.0.1:8000


### PR DESCRIPTION
## Summary
- ensure macOS and Ubuntu launcher scripts change into the project directory before running python -m ffarm
- avoid module import failures when launchers are started from Finder or other shells

## Testing
- not run (launcher script change only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690dadb5a84c83249885f492b856a8bc)